### PR TITLE
Add initializer for minor units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added initializer from a currency's minor units.
+  #15 by @mattt.
+
 ## [1.2.1] - 2020-11-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ let amount = Decimal(12)
 let monetaryAmount = Money<USD>(amount)
 ```
 
+Some currencies specify a minor unit.
+For example, USD amounts are often expressed in cents,
+each worth 1/100 of a dollar.
+You can initialize monetary amounts from a quantity of minor units.
+For currencies that don't have a minor unit,
+such as JPY,
+this is equivalent to the standard initializer.
+
+```swift
+let twoCents = Money<USD>(minorUnits: 2)
+twoCents.amount // 0.02
+
+let ichimonEn = Money<JPY>(minorUnits: 10_000)
+ichimonEn.amount // 10000
+```
+
 You can also create monetary amounts using
 integer, floating-point, and string literals.
 

--- a/Sources/Money/Money.swift
+++ b/Sources/Money/Money.swift
@@ -10,6 +10,17 @@ public struct Money<Currency: CurrencyType>: Equatable, Hashable {
         self.amount = amount
     }
 
+    public init(minorUnits: Int) {
+        precondition(Currency.minorUnit >= 0)
+
+        let sign: FloatingPointSign = minorUnits >= 0 ? .plus : .minus
+        let exponent = -Currency.minorUnit
+        let significand = Decimal(minorUnits)
+
+        let amount = Decimal(sign: sign, exponent: exponent, significand: significand)
+        self.init(amount)
+    }
+
     /// The currency type.
     public var currency: CurrencyType.Type {
         return Currency.self

--- a/Tests/MoneyTests/MoneyTests.swift
+++ b/Tests/MoneyTests/MoneyTests.swift
@@ -14,7 +14,16 @@ final class MoneyTests: XCTestCase {
         XCTAssertEqual(total.amount, Decimal(string: "39.45", locale: nil))
     }
 
+    func testMinorUnits() {
+        let twoCents = Money<USD>(minorUnits: 2) // $0.02
+        XCTAssertEqual(twoCents.amount, Decimal(string: "0.02", locale: nil))
+
+        let ichimonEn = Money<JPY>(minorUnits: 10_000) // ¥10,000
+        XCTAssertEqual(ichimonEn.amount, Decimal(string: "10000", locale: nil))
+    }
+
     static var allTests = [
         ("testMonetaryCalculations", testMonetaryCalculations),
+        ("testMinorUnits", testMinorUnits),
     ]
 }


### PR DESCRIPTION
As discussed in https://github.com/Flight-School/Money/issues/14#issuecomment-812541152

This PR adds a `Money` initializer that takes a quantity of minor units.

```swift
let twoCents = Money<USD>(minorUnits: 2)
twoCents.amount // 0.02

let ichimonEn = Money<JPY>(minorUnits: 10_000)
ichimonEn.amount // 10000
```