### PR TITLE
Add top-level iso4217Currency(for:) function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added initializer from a currency's minor units.
   #15 by @mattt.
+- Added top-level `iso4217Currency(for:)` function.
+  #16 by @mattt.
 
 ## [1.2.1] - 2020-11-09
 

--- a/README.md
+++ b/README.md
@@ -389,6 +389,14 @@ $ make
 > Please [open an issue](https://github.com/Flight-School/Money/issues/new)
 > if you're aware of any new amendments made to ISO 4217.
 
+You can lookup any built-in currency types by its three-letter code
+using the `iso4217Currency(for:)` function.
+
+```swift
+iso4217Currency(for: "USD")?.name // "US Dollar"
+iso4217Currency(for: "invalid") // nil
+```
+
 ### Adding Custom Currencies
 
 You can create your own custom currency types by defining an enumeration
@@ -418,6 +426,10 @@ formatter.maximumFractionDigits = 8
 
 formatter.string(for: satoshi.amount) // ₿0.00000001
 ```
+
+> **Important**:
+> The `iso4217Currency(for:) returns only built-in currencies,
+> so calling `iso4217Currency(for: "BTC")` would return `nil`.
 
 ### Showing Off with Emoji
 

--- a/Sources/Money/Currency.swift
+++ b/Sources/Money/Currency.swift
@@ -23,6 +23,186 @@ public protocol CurrencyType {
     static var minorUnit: Int { get }
 }
 
+/// Returns the ISO 4217 currency associated with a given code.
+///
+/// Currency codes are checked according to a strict, case-sensitive equality comparison.
+///
+/// - Important: This method returns only currencies defined in the `Money` module.
+///              For example,
+///              if you define a new type that adopts `CurrencyType`,
+///              calling this method with that currency type's `code` returns `nil`.
+///
+///
+/// - Parameter code: The ISO 4217 currency code
+/// - Returns: A `CurrencyType` type, if one
+public func iso4217Currency(for code: String) -> CurrencyType.Type? {
+    switch code {
+    case "AED": return AED.self
+    case "AFN": return AFN.self
+    case "ALL": return ALL.self
+    case "AMD": return AMD.self
+    case "ANG": return ANG.self
+    case "AOA": return AOA.self
+    case "ARS": return ARS.self
+    case "AUD": return AUD.self
+    case "AWG": return AWG.self
+    case "AZN": return AZN.self
+    case "BAM": return BAM.self
+    case "BBD": return BBD.self
+    case "BDT": return BDT.self
+    case "BGN": return BGN.self
+    case "BHD": return BHD.self
+    case "BIF": return BIF.self
+    case "BMD": return BMD.self
+    case "BND": return BND.self
+    case "BOB": return BOB.self
+    case "BOV": return BOV.self
+    case "BRL": return BRL.self
+    case "BSD": return BSD.self
+    case "BTN": return BTN.self
+    case "BWP": return BWP.self
+    case "BYN": return BYN.self
+    case "BZD": return BZD.self
+    case "CAD": return CAD.self
+    case "CDF": return CDF.self
+    case "CHE": return CHE.self
+    case "CHF": return CHF.self
+    case "CHW": return CHW.self
+    case "CLF": return CLF.self
+    case "CLP": return CLP.self
+    case "CNY": return CNY.self
+    case "COP": return COP.self
+    case "COU": return COU.self
+    case "CRC": return CRC.self
+    case "CUC": return CUC.self
+    case "CUP": return CUP.self
+    case "CVE": return CVE.self
+    case "CZK": return CZK.self
+    case "DJF": return DJF.self
+    case "DKK": return DKK.self
+    case "DOP": return DOP.self
+    case "DZD": return DZD.self
+    case "EGP": return EGP.self
+    case "ERN": return ERN.self
+    case "ETB": return ETB.self
+    case "EUR": return EUR.self
+    case "FJD": return FJD.self
+    case "FKP": return FKP.self
+    case "GBP": return GBP.self
+    case "GEL": return GEL.self
+    case "GHS": return GHS.self
+    case "GIP": return GIP.self
+    case "GMD": return GMD.self
+    case "GNF": return GNF.self
+    case "GTQ": return GTQ.self
+    case "GYD": return GYD.self
+    case "HKD": return HKD.self
+    case "HNL": return HNL.self
+    case "HRK": return HRK.self
+    case "HTG": return HTG.self
+    case "HUF": return HUF.self
+    case "IDR": return IDR.self
+    case "ILS": return ILS.self
+    case "INR": return INR.self
+    case "IQD": return IQD.self
+    case "IRR": return IRR.self
+    case "ISK": return ISK.self
+    case "JMD": return JMD.self
+    case "JOD": return JOD.self
+    case "JPY": return JPY.self
+    case "KES": return KES.self
+    case "KGS": return KGS.self
+    case "KHR": return KHR.self
+    case "KMF": return KMF.self
+    case "KPW": return KPW.self
+    case "KRW": return KRW.self
+    case "KWD": return KWD.self
+    case "KYD": return KYD.self
+    case "KZT": return KZT.self
+    case "LAK": return LAK.self
+    case "LBP": return LBP.self
+    case "LKR": return LKR.self
+    case "LRD": return LRD.self
+    case "LSL": return LSL.self
+    case "LYD": return LYD.self
+    case "MAD": return MAD.self
+    case "MDL": return MDL.self
+    case "MGA": return MGA.self
+    case "MKD": return MKD.self
+    case "MMK": return MMK.self
+    case "MNT": return MNT.self
+    case "MOP": return MOP.self
+    case "MRU": return MRU.self
+    case "MUR": return MUR.self
+    case "MVR": return MVR.self
+    case "MWK": return MWK.self
+    case "MXN": return MXN.self
+    case "MXV": return MXV.self
+    case "MYR": return MYR.self
+    case "MZN": return MZN.self
+    case "NAD": return NAD.self
+    case "NGN": return NGN.self
+    case "NIO": return NIO.self
+    case "NOK": return NOK.self
+    case "NPR": return NPR.self
+    case "NZD": return NZD.self
+    case "OMR": return OMR.self
+    case "PAB": return PAB.self
+    case "PEN": return PEN.self
+    case "PGK": return PGK.self
+    case "PHP": return PHP.self
+    case "PKR": return PKR.self
+    case "PLN": return PLN.self
+    case "PYG": return PYG.self
+    case "QAR": return QAR.self
+    case "RON": return RON.self
+    case "RSD": return RSD.self
+    case "RUB": return RUB.self
+    case "RWF": return RWF.self
+    case "SAR": return SAR.self
+    case "SBD": return SBD.self
+    case "SCR": return SCR.self
+    case "SDG": return SDG.self
+    case "SEK": return SEK.self
+    case "SGD": return SGD.self
+    case "SHP": return SHP.self
+    case "SLL": return SLL.self
+    case "SOS": return SOS.self
+    case "SRD": return SRD.self
+    case "SSP": return SSP.self
+    case "STN": return STN.self
+    case "SVC": return SVC.self
+    case "SYP": return SYP.self
+    case "SZL": return SZL.self
+    case "THB": return THB.self
+    case "TJS": return TJS.self
+    case "TMT": return TMT.self
+    case "TND": return TND.self
+    case "TOP": return TOP.self
+    case "TRY": return TRY.self
+    case "TTD": return TTD.self
+    case "TWD": return TWD.self
+    case "TZS": return TZS.self
+    case "UAH": return UAH.self
+    case "UGX": return UGX.self
+    case "USD": return USD.self
+    case "UYI": return UYI.self
+    case "UYU": return UYU.self
+    case "UZS": return UZS.self
+    case "VEF": return VEF.self
+    case "VND": return VND.self
+    case "VUV": return VUV.self
+    case "WST": return WST.self
+    case "XCD": return XCD.self
+    case "YER": return YER.self
+    case "ZAR": return ZAR.self
+    case "ZMW": return ZMW.self
+    case "ZWL": return ZWL.self
+    default:
+        return nil
+    }
+}
+
 /// UAE Dirham (AED)
 public enum AED: CurrencyType {
     public static var code: String {

--- a/Sources/Money/Currency.swift
+++ b/Sources/Money/Currency.swift
@@ -27,10 +27,10 @@ public protocol CurrencyType {
 ///
 /// Currency codes are checked according to a strict, case-sensitive equality comparison.
 ///
-/// - Important: This method returns only currencies defined in the `Money` module.
+/// - Important: This function returns only currencies defined in the `Money` module.
 ///              For example,
 ///              if you define a new type that adopts `CurrencyType`,
-///              calling this method with that currency type's `code` returns `nil`.
+///              calling `iso4217Currency(for:)` with that currency type's `code` returns `nil`.
 ///
 ///
 /// - Parameter code: The ISO 4217 currency code

--- a/Sources/Money/Currency.swift.gyb
+++ b/Sources/Money/Currency.swift.gyb
@@ -24,6 +24,37 @@ public protocol CurrencyType {
     static var minorUnit: Int { get }
 }
 
+/// Returns the ISO 4217 currency associated with a given code.
+///
+/// Currency codes are checked according to a strict, case-sensitive equality comparison.
+///
+/// - Important: This method returns only currencies defined in the `Money` module.
+///              For example,
+///              if you define a new type that adopts `CurrencyType`,
+///              calling this method with that currency type's `code` returns `nil`.
+///
+/// - Parameter code: The ISO 4217 currency code
+/// - Returns: A `CurrencyType` type, if one
+public func iso4217Currency(for code: String) -> CurrencyType.Type? {
+    switch code {
+%{
+  import csv
+}%
+% with open('../../Resources/iso4217.csv') as file:
+    % for row in csv.DictReader(file):
+%{
+code = row["Code"]
+}%
+        % if code:
+    case "${code}": return ${code}.self
+        %end
+    %end
+%end
+    default:
+        return nil
+    }
+}
+
 %{
   import csv
 }%

--- a/Tests/MoneyTests/CurrencyTests.swift
+++ b/Tests/MoneyTests/CurrencyTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import Foundation
+@testable import Money
+
+final class CurrencyTests: XCTestCase {
+    func testCurrencyByISO4217Code() {
+        let usd = iso4217Currency(for: "USD")
+        XCTAssert(usd == USD.self)
+        XCTAssertEqual(usd?.code, "USD")
+        XCTAssertEqual(usd?.name, "US Dollar")
+        XCTAssertEqual(usd?.minorUnit, 2)
+
+        let unk = iso4217Currency(for: "UNK")
+        XCTAssertNil(unk)
+    }
+
+    static var allTests = [
+        ("testCurrencyByISO4217Code", testCurrencyByISO4217Code),
+    ]
+}

--- a/Tests/MoneyTests/XCTestManifests.swift
+++ b/Tests/MoneyTests/XCTestManifests.swift
@@ -3,6 +3,7 @@ import XCTest
 #if !os(macOS)
 public func allTests() -> [XCTestCaseEntry] {
     return [
+        testCase(CurrencyTests.allTests),
         testCase(MoneyTests.allTests),
         testCase(DecodingTests.allTests),
         testCase(EncodingTests.allTests),


### PR DESCRIPTION
As discussed in https://github.com/Flight-School/Money/issues/14#issuecomment-812541152

You can lookup any built-in currency types by its three-letter code
using the `iso4217Currency(for:)` function.

```swift
iso4217Currency(for: "USD")?.name // "US Dollar"
iso4217Currency(for: "invalid") // nil
```