### PR TITLE
Update money negation docstring

### DIFF
--- a/Sources/Money/Money.swift
+++ b/Sources/Money/Money.swift
@@ -72,7 +72,7 @@ extension Money {
 }
 
 extension Money {
-    /// Subtracts one monetary amount from another.
+    /// Changes the sign (plus to minus or vice versa) of the monetary amount.
     public static prefix func - (value: Money<Currency>) -> Money<Currency> {
         return Money<Currency>(-value.amount)
     }

--- a/Sources/Money/Money.swift
+++ b/Sources/Money/Money.swift
@@ -72,7 +72,7 @@ extension Money {
 }
 
 extension Money {
-    /// Flips the sign (plus to minus or vice versa) of the monetary amount.
+    /// Negates the monetary amount.
     public static prefix func - (value: Money<Currency>) -> Money<Currency> {
         return Money<Currency>(-value.amount)
     }

--- a/Sources/Money/Money.swift
+++ b/Sources/Money/Money.swift
@@ -72,7 +72,7 @@ extension Money {
 }
 
 extension Money {
-    /// Changes the sign (plus to minus or vice versa) of the monetary amount.
+    /// Flips the sign (plus to minus or vice versa) of the monetary amount.
     public static prefix func - (value: Money<Currency>) -> Money<Currency> {
         return Money<Currency>(-value.amount)
     }


### PR DESCRIPTION
It looks like this was copied directly from

```swift
    /// The difference between two monetary amounts.
    public static func - (lhs: Money<Currency>, rhs: Money<Currency>) -> Money<Currency> {
        return Money<Currency>(lhs.amount - rhs.amount)
    }
```

I _think_ this updated phrasing reflects the behavior correctly, but I'm only using the library as a reference so I might be misunderstanding this.