### PR TITLE
Make it easier to specify custom coding keys

### DIFF
--- a/Sources/Money/Money.swift
+++ b/Sources/Money/Money.swift
@@ -217,6 +217,17 @@ extension Money: ExpressibleByStringLiteral {
 
 // MARK: - Codable
 
+/**
+ Coding keys for `Money` values.
+ */
+public enum MoneyCodingKeys: String, CodingKey {
+    /// The coding key for the `amount` property.
+    case amount
+
+    /// The coding key for the `currencyCode` property
+    case currencyCode
+}
+
 extension CodingUserInfoKey {
     /**
      The key for specifying custom decoding options for `Money` values.
@@ -313,15 +324,10 @@ public struct MoneyEncodingOptions: OptionSet {
 }
 
 extension Money: Codable {
-    private enum CodingKeys: String, CodingKey {
-        case amount
-        case currencyCode
-    }
-
     public init(from decoder: Decoder) throws {
         let options = decoder.userInfo[.moneyDecodingOptions] as? MoneyDecodingOptions ?? []
 
-        if let keyedContainer = try? decoder.container(keyedBy: CodingKeys.self) {
+        if let keyedContainer = try? decoder.container(keyedBy: MoneyCodingKeys.self) {
             let currencyCode = try keyedContainer.decode(String.self, forKey: .currencyCode)
             guard currencyCode == Currency.code else {
                 let context = DecodingError.Context(codingPath: keyedContainer.codingPath, debugDescription: "Currency mismatch: expected \(Currency.code), got \(currencyCode)")
@@ -378,7 +384,7 @@ extension Money: Codable {
                 try singleValueContainer.encode(self.amount)
             }
         } else {
-            var keyedContainer = encoder.container(keyedBy: CodingKeys.self)
+            var keyedContainer = encoder.container(keyedBy: MoneyCodingKeys.self)
             try keyedContainer.encode(Currency.code, forKey: .currencyCode)
             if options.contains(.encodeAmountAsString) {
                 try keyedContainer.encode(self.amount.description, forKey: .amount)

--- a/Tests/MoneyTests/DecodingTests.swift
+++ b/Tests/MoneyTests/DecodingTests.swift
@@ -54,6 +54,39 @@ final class DecodingTests: XCTestCase {
         }
     }
 
+    func testDecodeKeyedContainerWithCustomKeys() throws {
+        let json = #"""
+             {
+                 "value": "27.31",
+                 "currency": "USD"
+             }
+         """#.data(using: .utf8)!
+
+        decoder.keyDecodingStrategy = .custom({ keys in
+            switch keys.last?.stringValue {
+            case "value":
+                return MoneyCodingKeys.amount
+            case "currency":
+                return MoneyCodingKeys.currencyCode
+            default:
+                return keys.last!
+            }
+        })
+
+        do {
+            XCTAssertNoThrow(try decoder.decode(Money<USD>.self, from: json))
+        }
+
+        do {
+            decoder.moneyDecodingOptions = [.requireStringAmount]
+
+            let actual = try decoder.decode(Money<USD>.self, from: json)
+            let expected = Money<USD>(Decimal(string: "27.31")!)
+
+            XCTAssertEqual(actual, expected)
+        }
+    }
+
     func testDecodeKeyedContainerWithPreciseStringAmount() throws {
         let json = #"""
              {

--- a/Tests/MoneyTests/DecodingTests.swift
+++ b/Tests/MoneyTests/DecodingTests.swift
@@ -87,6 +87,41 @@ final class DecodingTests: XCTestCase {
         }
     }
 
+    func testDecodeWithIntermediaryObject() throws {
+        struct Item: Codable {
+            struct Price: Codable {
+                let value: String
+                let currency: String
+            }
+
+            let name: String
+            private let unitPrice: Price
+
+            var unitPriceInUSD: Money<USD>? {
+                guard unitPrice.currency == USD.code else { return nil }
+                return Money(unitPrice.value)
+            }
+        }
+
+        let json = #"""
+             {
+                 "name": "Widget",
+                 "unitPrice": {
+                    "value": "3.33",
+                    "currency": "USD"
+                 }
+             }
+         """#.data(using: .utf8)!
+
+
+        do {
+            let actual = try decoder.decode(Item.self, from: json).unitPriceInUSD
+            let expected = Money<USD>(Decimal(string: "3.33")!)
+
+            XCTAssertEqual(actual, expected)
+        }
+    }
+
     func testDecodeKeyedContainerWithPreciseStringAmount() throws {
         let json = #"""
              {

--- a/Tests/MoneyTests/EncodingTests.swift
+++ b/Tests/MoneyTests/EncodingTests.swift
@@ -33,6 +33,41 @@ final class EncodingTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func testEncodeKeyedContainerWithCustomKeys() throws {
+        struct AnyKey: CodingKey {
+            var stringValue: String
+            var intValue: Int?
+
+            init(stringValue: String) {
+                self.stringValue = stringValue
+                self.intValue = nil
+            }
+
+            init(intValue: Int) {
+                self.stringValue = String(intValue)
+                self.intValue = intValue
+            }
+        }
+
+        encoder.keyEncodingStrategy = .custom({ keys in
+            switch keys.last {
+            case MoneyCodingKeys.amount?:
+                return AnyKey(stringValue: "value")
+            case MoneyCodingKeys.currencyCode?:
+                return AnyKey(stringValue: "currency")
+            default:
+                return keys.last!
+            }
+        })
+
+        let data = try encoder.encode(money)
+        let actual = String(data: data, encoding: .utf8)
+
+        let expected = #"{"currency":"USD","value":27.31}"#
+
+        XCTAssertEqual(actual, expected)
+    }
+
     func testEncodeSingleValueContainerWithNumberAmount() throws {
         encoder.moneyEncodingOptions = [.omitCurrency]
 


### PR DESCRIPTION
Resolves #18

By default, `Money` values are encoded and decoded with the string keys `"amount"` and `"currencyCode"`, which correspond to their respective properties.

This PR makes the private `Money.CodingKeys` enumeration a public type, `MoneyCodingKeys`, which allows consumers to customize the key names for decoding `Money` values like this:

```swift
let json = #"""
 {
    "value": "3.33",
    "currency": "USD"
 }
 """#.data(using: .utf8)!

let decoder = JSONDecoder()
decoder.keyDecodingStrategy = .custom({ keys in
    switch keys.last?.stringValue {
    case "value":
        return MoneyCodingKeys.amount
    case "currency":
        return MoneyCodingKeys.currencyCode
    default:
        return keys.last!
    }
})

let amount = try decoder.decode(Money<USD>.self, from: json) // $3.33
```