### PR TITLE
Add XAF, XOF and XPF currencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 Sources/Money/Currency.swift: Resources/iso4217.csv
 
 %.swift: %.swift.gyb
-	@gyb --line-directive '' -o $@ $<
+	@./gyb --line-directive '' -o $@ $<
 
 .PHONY:
 clean:

--- a/Resources/iso4217.csv
+++ b/Resources/iso4217.csv
@@ -155,7 +155,10 @@ VEF,Bolívar,2
 VND,Dong,0
 VUV,Vatu,0
 WST,Tala,2
+XAF,CFA franc BEAC,0
 XCD,East Caribbean Dollar,2
+XOF,CFA franc BCEAO,0
+XPF,CFP franc (franc Pacifique),0
 YER,Yemeni Rial,2
 ZAR,Rand,2
 ZMW,Zambian Kwacha,2

--- a/Sources/Money/Currency.swift
+++ b/Sources/Money/Currency.swift
@@ -193,7 +193,10 @@ public func iso4217Currency(for code: String) -> CurrencyType.Type? {
     case "VND": return VND.self
     case "VUV": return VUV.self
     case "WST": return WST.self
+    case "XAF": return XAF.self
     case "XCD": return XCD.self
+    case "XOF": return XOF.self
+    case "XPF": return XPF.self
     case "YER": return YER.self
     case "ZAR": return ZAR.self
     case "ZMW": return ZMW.self
@@ -2543,6 +2546,21 @@ public enum WST: CurrencyType {
     }
 }
 
+/// CFA franc BEAC (XAF)
+public enum XAF: CurrencyType {
+    public static var code: String {
+        return "XAF"
+    }
+
+    public static var name: String {
+        return "CFA franc BEAC"
+    }
+
+    public static var minorUnit: Int {
+        return 0
+    }
+}
+
 /// East Caribbean Dollar (XCD)
 public enum XCD: CurrencyType {
     public static var code: String {
@@ -2555,6 +2573,36 @@ public enum XCD: CurrencyType {
 
     public static var minorUnit: Int {
         return 2
+    }
+}
+
+/// CFA franc BCEAO (XOF)
+public enum XOF: CurrencyType {
+    public static var code: String {
+        return "XOF"
+    }
+
+    public static var name: String {
+        return "CFA franc BCEAO"
+    }
+
+    public static var minorUnit: Int {
+        return 0
+    }
+}
+
+/// CFP franc (franc Pacifique) (XPF)
+public enum XPF: CurrencyType {
+    public static var code: String {
+        return "XPF"
+    }
+
+    public static var name: String {
+        return "CFP franc (franc Pacifique)"
+    }
+
+    public static var minorUnit: Int {
+        return 0
     }
 }
 


### PR DESCRIPTION
I noticed 3 currencies that are featured in the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) list were missing in the library.

To be honest I could not run `gyb` easily since the one from [the archived Brew recipe](https://github.com/nshipster/homebrew-formulae/blob/HEAD/Formula/gyb.rb) seems to rely on python@2.7 and I ran into trouble running [the most recent version from Apple](https://github.com/apple/swift/blob/main/utils/gyb.py).

So I added the missing by hand both in the `csv` file and the `.swift` code. I hope I didn't miss anything.

🙏
